### PR TITLE
Fix login for EasyEquities' OIDC + MFA migration; add REST API with HTML-scraping fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,16 @@ Instruments:
 ## Usage
 
 ```python
-from easy_equities_client.clients import EasyEquitiesClient # or SatrixClient
+from easy_equities_client.clients import EasyEquitiesClient, MfaRequiredError # or SatrixClient
 
 client = EasyEquitiesClient()
-client.login(username='your username', password='your password')
+try:
+    client.login(username='your username', password='your password')
+except MfaRequiredError:
+    # EasyEquities now requires an authenticator-app (TOTP) code on every
+    # login - get the current 6-digit code from your app and complete
+    # login on the same client instance.
+    client.verify_mfa(code=input("Authenticator code: "))
 
 # List accounts
 accounts = client.accounts.list()

--- a/src/easy_equities_client/accounts/clients.py
+++ b/src/easy_equities_client/accounts/clients.py
@@ -24,6 +24,19 @@ from easy_equities_client.types import Client
 logger = logging.getLogger(__name__)
 
 
+class UnsupportedAccountError(Exception):
+    """
+    Raised when an "account" from AccountsClient.list() isn't actually a
+    trust account on this platform - EasyProperties, EasyCrypto, and other
+    EasyEquities-family products appear in the same account list, but are
+    hosted on entirely separate sites (their own login, their own data).
+    Switching to one doesn't select anything server-side here - it's a
+    signal meant for a browser to open a new tab - so silently proceeding
+    would leave whatever account was previously active still selected,
+    corrupting the next holdings()/valuations() call for this account_id.
+    """
+
+
 class AccountsClient(Client):
     def __init__(self, base_url: str = "", session: Session = None):
         super().__init__(base_url, session)
@@ -45,6 +58,10 @@ class AccountsClient(Client):
     def _switch_account(self, account_id: str) -> None:
         """
         Switch the currently selected account to account with ID account_id.
+
+        :raises UnsupportedAccountError: if account_id belongs to a
+            different EasyEquities-family platform (EasyProperties,
+            EasyCrypto, ...) rather than a real trust account here.
         """
         if self.current_account != account_id:
             data = {"trustAccountId": account_id}
@@ -55,6 +72,12 @@ class AccountsClient(Client):
             assert response.status_code == 200, (
                 "Update currency request should return 200 status code"
             )
+            if response.text.strip().strip('"').startswith("NEWTAB-"):
+                target = response.text.strip().strip('"')[len("NEWTAB-") :]
+                raise UnsupportedAccountError(
+                    f"Account {account_id} is hosted on a separate platform ({target}) - "
+                    "its holdings can't be fetched through this client."
+                )
             self.current_account = account_id
 
     def valuations(self, account_id: str) -> Valuation:

--- a/src/easy_equities_client/accounts/clients.py
+++ b/src/easy_equities_client/accounts/clients.py
@@ -12,6 +12,13 @@ from easy_equities_client.accounts.parsers import (
     AccountOverviewParser,
     get_transactions_from_page,
 )
+from easy_equities_client.accounts.rest import (
+    PortfolioApiError,
+    account_id_from_account_number,
+    fetch_portfolio_overview,
+    rest_account_to_account,
+    rest_assets_to_holdings,
+)
 from easy_equities_client.accounts.types import (
     Account,
     Holding,
@@ -166,3 +173,69 @@ class AccountsClient(Client):
                 ).next_sibling.next_sibling.text.strip()
                 holding["shares"] = f"{whole_shares}{partial_shares}"
         return holdings
+
+
+class EasyEquitiesAccountsClient(AccountsClient):
+    """
+    Same as AccountsClient, but tries the modern portfolio-overview REST
+    API first (see easy_equities_client.accounts.rest) - one JSON call
+    covering every EasyEquities-family account, including EasyProperties
+    and EasyCrypto, which the HTML-scraped account list can't reach at
+    all (they live on entirely separate sites). Falls back to the
+    existing HTML-scraping behavior if the REST API is unavailable for
+    any reason, so callers keep working even if EasyEquities changes or
+    restricts it.
+    """
+
+    def __init__(self, base_url: str = "", session: Session = None):
+        super().__init__(base_url, session)
+        self._portfolio_cache: Optional[dict] = None
+
+    def _portfolio(self) -> dict:
+        # Cached per instance - list() followed by holdings() for each of
+        # its accounts would otherwise redo the whole silent-reauth +
+        # token exchange + REST call every time, even though one response
+        # already has everything.
+        if self._portfolio_cache is None:
+            self._portfolio_cache = fetch_portfolio_overview(self.session)
+        return self._portfolio_cache
+
+    def list(self) -> List[Account]:
+        try:
+            portfolio = self._portfolio()
+        except PortfolioApiError as exc:
+            logger.warning(
+                f"Portfolio API unavailable, falling back to HTML scraping: {exc}"
+            )
+            return super().list()
+        return [
+            rest_account_to_account(entry)
+            for entry in portfolio.get("investmentAccounts", [])
+        ]
+
+    def holdings(self, account_id: str, include_shares: bool = False) -> List[Holding]:
+        try:
+            portfolio = self._portfolio()
+        except PortfolioApiError as exc:
+            logger.warning(
+                f"Portfolio API unavailable, falling back to HTML scraping: {exc}"
+            )
+            return super().holdings(account_id, include_shares=include_shares)
+
+        for entry in portfolio.get("investmentAccounts", []):
+            if (
+                account_id_from_account_number(entry.get("accountNumber", ""))
+                == account_id
+            ):
+                # include_shares has no REST equivalent (no per-holding
+                # detail page to fetch from) - the HTML-scraped units
+                # count is already in the mapped holding either way.
+                return rest_assets_to_holdings(entry)
+
+        # Not present in the REST response at all - shouldn't normally
+        # happen since it returns everything, but fall back rather than
+        # silently returning nothing for a real account_id.
+        logger.warning(
+            f"Account {account_id} not found in the portfolio API response, falling back to HTML scraping"
+        )
+        return super().holdings(account_id, include_shares=include_shares)

--- a/src/easy_equities_client/accounts/rest.py
+++ b/src/easy_equities_client/accounts/rest.py
@@ -1,0 +1,212 @@
+"""
+Modern REST API used by the portfolio-overview web app
+(portfolio-overview.apps.easyequities.io) - a separate SPA from
+platform.easyequities.io, registered as its own OAuth2 client, calling a
+clean JSON API instead of platform.easyequities.io's server-rendered
+pages.
+
+This is EasyEquities-specific (Satrix has no equivalent app/API as far as
+this library knows), reverse-engineered from that SPA's own network
+traffic rather than documented anywhere, so it's used as the *preferred*
+source with the existing HTML-scraping AccountsClient as a fallback -
+see EasyEquitiesAccountsClient. If EasyEquities changes or restricts this
+API, callers keep working via the fallback rather than breaking outright.
+"""
+
+import base64
+import hashlib
+import os
+from urllib.parse import parse_qs, urlparse
+
+from requests import Session
+
+from easy_equities_client.accounts.types import Account, Holding
+
+# Registered specifically to the portfolio-overview SPA - different from
+# the client_id PlatformClient.login() uses for the platform.easyequities.io
+# login itself.
+CLIENT_ID = "fa4d2622bc1e45a7be79395d941e2548"
+REDIRECT_URI = "https://portfolio-overview.apps.easyequities.io/auth/callback"
+SCOPE = "openid profile api_gateway user_profile_api static_data_api easy_protect_api easy_lending_api thrive_api"
+PORTFOLIO_OVERVIEW_URL = (
+    "https://rest.synatic.openeasy.io/easyequities/portfolios/v3/portfolio-overview"
+)
+
+
+class PortfolioApiError(Exception):
+    """Raised for any failure obtaining or using the portfolio REST API -
+    callers should catch this specifically and fall back to HTML scraping."""
+
+
+def _generate_pkce_pair() -> tuple[str, str]:
+    verifier = base64.urlsafe_b64encode(os.urandom(32)).decode().rstrip("=")
+    challenge = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
+        .decode()
+        .rstrip("=")
+    )
+    return verifier, challenge
+
+
+def get_portfolio_access_token(session: Session) -> str:
+    """
+    Given a session already authenticated against identity.openeasy.io
+    (via PlatformClient.login()/verify_mfa()), silently obtains a Bearer
+    access token for the portfolio-overview REST API.
+
+    The session's existing SSO cookie means requesting a fresh
+    authorization code for this API's own OAuth2 client redirects straight
+    back with a code - no login or MFA prompt - which is then exchanged
+    for an access token via the standard PKCE authorization_code grant
+    (the code_verifier/code_challenge pair is generated fresh here, no
+    dependency on how the session was originally authenticated).
+
+    :raises PortfolioApiError: if the silent re-authorization or token
+        exchange fails for any reason (e.g. the session isn't actually
+        authenticated, or EasyEquities changed this flow).
+    """
+    code_verifier, code_challenge = _generate_pkce_pair()
+
+    try:
+        authorize_response = session.get(
+            "https://identity.openeasy.io/connect/authorize",
+            params={
+                "client_id": CLIENT_ID,
+                "redirect_uri": REDIRECT_URI,
+                "response_type": "code",
+                "scope": SCOPE,
+                "code_challenge": code_challenge,
+                "code_challenge_method": "S256",
+                "response_mode": "query",
+            },
+            allow_redirects=False,
+        )
+    except Exception as exc:
+        raise PortfolioApiError(
+            f"Could not reach identity.openeasy.io for portfolio access: {exc}"
+        ) from exc
+
+    if authorize_response.status_code != 302:
+        raise PortfolioApiError(
+            f"Unexpected response requesting portfolio access (status {authorize_response.status_code}) - "
+            "the session may not be logged in"
+        )
+
+    location = authorize_response.headers.get("Location", "")
+    code = parse_qs(urlparse(location).query).get("code", [None])[0]
+    if not code:
+        raise PortfolioApiError(
+            "Did not receive an authorization code for the portfolio API"
+        )
+
+    try:
+        token_response = session.post(
+            "https://identity.openeasy.io/connect/token",
+            data={
+                "grant_type": "authorization_code",
+                "client_id": CLIENT_ID,
+                "code_verifier": code_verifier,
+                "code": code,
+                "redirect_uri": REDIRECT_URI,
+            },
+        )
+        token_data = token_response.json()
+    except Exception as exc:
+        raise PortfolioApiError(
+            f"Could not exchange the authorization code for a token: {exc}"
+        ) from exc
+
+    access_token = token_data.get("access_token")
+    if not access_token:
+        raise PortfolioApiError(f"Token response had no access_token: {token_data}")
+    return access_token
+
+
+def fetch_portfolio_overview(session: Session) -> dict:
+    """
+    Fetches the raw portfolio-overview JSON: every EasyEquities-family
+    account (including EasyProperties/EasyCrypto, which live on entirely
+    separate sites and have no equivalent in AccountsClient's HTML-scraped
+    account list) with exact current/purchase values, in one call.
+
+    :raises PortfolioApiError: if the access token or the API call fails.
+    """
+    access_token = get_portfolio_access_token(session)
+    try:
+        response = session.get(
+            PORTFOLIO_OVERVIEW_URL,
+            headers={
+                "Authorization": f"Bearer {access_token}",
+                "Accept": "application/json, text/plain, */*",
+            },
+        )
+    except Exception as exc:
+        raise PortfolioApiError(f"Could not reach the portfolio API: {exc}") from exc
+
+    if response.status_code != 200:
+        raise PortfolioApiError(f"Portfolio API returned status {response.status_code}")
+
+    try:
+        return response.json()
+    except Exception as exc:
+        raise PortfolioApiError(
+            f"Portfolio API returned an unexpected (non-JSON) response: {exc}"
+        ) from exc
+
+
+def account_id_from_account_number(account_number: str) -> str:
+    """A regular trust account's accountNumber is "<entity>-<numeric id>" -
+    that numeric id matches the id AccountsClient's HTML-scraping already
+    uses, so an account linked via one source keeps the same id via the
+    other. EasyEquities-family products that aren't a numbered trust
+    account (EasyCrypto) get their own standalone reference instead."""
+    suffix = account_number.rsplit("-", 1)[-1]
+    return suffix if suffix.isdigit() else account_number
+
+
+def rest_account_to_account(entry: dict) -> Account:
+    account_number = entry.get("accountNumber", "")
+    product_id = entry.get("productId")
+    return Account(
+        id=account_id_from_account_number(account_number),
+        name=entry.get("productName", account_number),
+        trading_currency_id=str(product_id) if product_id is not None else "",
+    )
+
+
+def _format_currency(amount: float, symbol: str) -> str:
+    """Matches the string format AccountHoldingsParser scrapes from the
+    HTML pages (e.g. "R2 490.68", "-$0.11") - space-grouped thousands, no
+    space between the symbol and the number - so a Holding built from
+    either source looks the same to callers."""
+    sign = "-" if amount < 0 else ""
+    grouped = f"{abs(amount):,.2f}".replace(",", " ")
+    return f"{sign}{symbol}{grouped}"
+
+
+def rest_assets_to_holdings(account_entry: dict) -> list[Holding]:
+    """Best-effort mapping of one account's REST `assets` into the same
+    Holding shape AccountHoldingsParser produces from HTML. Not a perfect
+    match - the REST API has no equivalent of view_url (holding detail
+    page link), which HTML-scraped holdings.include_shares=True needs, so
+    that option only ever adds data via the HTML fallback."""
+    symbol = account_entry.get("currencySymbol", "")
+    holdings: list[Holding] = []
+    for asset in account_entry.get("assets", []):
+        holding: Holding = {
+            "name": asset.get("assetName", ""),
+            "contract_code": asset.get("contractCode", ""),
+            "purchase_value": _format_currency(asset.get("purchaseValue") or 0, symbol),
+            "current_value": _format_currency(asset.get("currentValue") or 0, symbol),
+            "current_price": _format_currency(asset.get("currentPrice") or 0, symbol),
+            "isin": asset.get("assetCode", ""),
+            "shares": str(asset.get("units", "")),
+        }
+        image_uri = asset.get("imageUri")
+        if image_uri:
+            try:
+                holding["img"] = base64.b64decode(image_uri).decode()
+            except Exception:
+                pass
+        holdings.append(holding)
+    return holdings

--- a/src/easy_equities_client/clients.py
+++ b/src/easy_equities_client/clients.py
@@ -1,11 +1,56 @@
-import urllib.parse
+import html
+import re
+from urllib.parse import urljoin
 
-from requests import Session
+from requests import Response, Session
 
 from easy_equities_client import constants
 from easy_equities_client.accounts.clients import AccountsClient
 from easy_equities_client.instruments.clients import InstrumentsClient
 from easy_equities_client.types import Client
+
+# EasyEquities' WAF blocks the default python-requests User-Agent outright
+# (403) before the request even reaches the login page - any realistic
+# browser UA gets through.
+_BROWSER_USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
+
+
+class MfaRequiredError(Exception):
+    """
+    Raised by PlatformClient.login() when EasyEquities requires an
+    authenticator-app (TOTP) code to finish signing in.
+
+    Call verify_mfa(code) on the same client instance, with the current
+    6-digit code from the person's authenticator app, to complete login.
+    """
+
+
+def _extract_value(name: str, html_text: str) -> str | None:
+    m = re.search(r'name="%s"[^>]*value="([^"]*)"' % re.escape(name), html_text)
+    return m.group(1) if m else None
+
+
+def _parse_auto_submit_form(html_text: str) -> tuple[str | None, dict[str, str]]:
+    """Parses an OIDC response_mode=form_post callback page: instead of an
+    HTTP redirect, the identity provider returns an HTML page with an
+    auto-submitting <form> that a real browser's JS posts immediately."""
+    form_match = re.search(
+        r"<form[^>]*action=['\"]([^'\"]*)['\"][^>]*>(.*?)</form>", html_text, re.DOTALL
+    )
+    if not form_match:
+        return None, {}
+    action = html.unescape(form_match.group(1))
+    fields = {
+        m.group(1): html.unescape(m.group(2))
+        for m in re.finditer(
+            r"<input[^>]*name=['\"]([^'\"]+)['\"][^>]*value=['\"]([^'\"]*)['\"]",
+            form_match.group(2),
+        )
+    }
+    return action, fields
 
 
 class PlatformClient(Client):
@@ -18,41 +63,142 @@ class PlatformClient(Client):
         super().__init__(base_url, session)
         self.accounts = AccountsClient(base_url, self.session)
         self.instruments = InstrumentsClient(base_url, self.session)
+        self._mfa_token: str | None = None
+        self._mfa_url: str | None = None
 
     def login(self, username: str, password: str) -> bool:
         """
         Login to the platform.
 
+        EasyEquities now routes login through a separate OIDC identity
+        provider (identity.openeasy.io, "EasyID") instead of handling it
+        directly on the platform site, and may require a TOTP
+        authenticator-app code as a second factor.
+
         :param username: Username.
         :param password: Password.
 
-        :return: boolean True if successfully logged in.
-        :raises Exception: if request failed.
+        :return: True if login completed without needing a second factor.
+        :raises MfaRequiredError: if an authenticator-app code is required -
+            call verify_mfa(code) on this same client to finish logging in.
+        :raises Exception: if the request failed outright (e.g. wrong
+            username/password, or EasyEquities changed their login page
+            again and the expected form fields weren't found).
         """
-        password = urllib.parse.quote(password)
-        username = urllib.parse.quote(username)
+        self.session.headers["User-Agent"] = _BROWSER_USER_AGENT
 
-        data = (
-            f"UserIdentifier={username}&Password={password}"
-            "&ReturnUrl=&OneSignalGameId=&IsUsingNewLayoutSatrixOrEasyEquitiesMobileApp=False"
-        )
-        self.session.headers["Accept"] = (
-            "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
-        )
-        self.session.headers["Connection"] = "keep-alive"
-        self.session.headers["Connection-Type"] = "application/x-www-form-urlencoded"
-        self.session.headers["Content-Type"] = "application/x-www-form-urlencoded"
+        signin_page = self.session.get(self._url(constants.PLATFORM_SIGN_IN_PATH))
+        token = _extract_value("__RequestVerificationToken", signin_page.text)
+        return_url = html.unescape(_extract_value("ReturnUrl", signin_page.text) or "")
+        client_id = _extract_value("ClientIdForProperties", signin_page.text)
+        if not token or not client_id:
+            raise Exception(
+                "Could not find the login form - EasyEquities may have changed their login page"
+            )
 
         response = self.session.post(
-            self._url(constants.PLATFORM_SIGN_IN_PATH),
-            data=data,
+            signin_page.url,
+            data={
+                "ReturnUrl": return_url,
+                "ClientIdForProperties": client_id,
+                "Response": "",
+                "Username": username,
+                "IsUsernameProvided": "False",
+                "Password": password,
+                "button": "login",
+                "__RequestVerificationToken": token,
+            },
             allow_redirects=False,
         )
-        response.raise_for_status()
         if response.status_code != 302:
-            raise Exception("Login failed")
+            raise Exception("Login failed - check your username/password")
 
+        next_location = response.headers.get("Location", "")
+        if "Mfa" not in next_location:
+            self._follow_oidc_redirect(response)
+            return True
+
+        mfa_url = urljoin(response.url, next_location)
+        mfa_page = self.session.get(mfa_url)
+        mfa_token = _extract_value("__RequestVerificationToken", mfa_page.text)
+        if not mfa_token:
+            raise Exception(
+                "Could not find the verification code form - EasyEquities may have changed their MFA page"
+            )
+
+        self._mfa_token = mfa_token
+        self._mfa_url = mfa_page.url
+        raise MfaRequiredError(
+            "An authenticator-app code is required - call verify_mfa(code) to continue."
+        )
+
+    def verify_mfa(self, code: str) -> bool:
+        """
+        Completes login after login() raised MfaRequiredError.
+
+        :param code: the current 6-digit code from the authenticator app.
+        :return: True once login is fully complete.
+        :raises Exception: if the code is invalid, or verification
+            otherwise failed.
+        """
+        if not self._mfa_url or not self._mfa_token:
+            raise Exception(
+                "verify_mfa() called without a pending MFA challenge - call login() first."
+            )
+
+        response = self.session.post(
+            self._mfa_url,
+            data={
+                "ProviderName": "totp",
+                "Code": code,
+                "button": "send",
+                "__RequestVerificationToken": self._mfa_token,
+                "RememberMe": "false",
+            },
+            allow_redirects=False,
+        )
+        if response.status_code == 200 and "Invalid Code" in response.text:
+            raise Exception("Invalid verification code")
+        if response.status_code not in (301, 302, 303, 307, 308):
+            raise Exception(
+                f"Unexpected response from EasyEquities during verification (status {response.status_code})"
+            )
+
+        self._follow_oidc_redirect(response)
+        self._mfa_token = None
+        self._mfa_url = None
         return True
+
+    def _follow_oidc_redirect(self, response: Response, max_hops: int = 10) -> None:
+        """Follows the rest of the OIDC callback chain back to the platform
+        site, given the response that started it (a 3xx redirect).
+
+        The final hop uses response_mode=form_post - an HTML page with an
+        auto-submitting <form> instead of a plain HTTP redirect - so plain
+        redirects alone aren't enough to complete authentication. Every hop
+        is resolved with urljoin() against the *actual* URL of the response
+        that produced it (not a hardcoded host), since this chain crosses
+        from the identity provider back to the platform site partway
+        through.
+        """
+        hops = 0
+        while hops < max_hops:
+            if response.status_code in (301, 302, 303, 307, 308):
+                next_url = urljoin(response.url, response.headers.get("Location", ""))
+                response = self.session.get(next_url, allow_redirects=False)
+                hops += 1
+                continue
+
+            action, fields = _parse_auto_submit_form(response.text)
+            if action and fields:
+                next_url = urljoin(response.url, action)
+                response = self.session.post(
+                    next_url, data=fields, allow_redirects=False
+                )
+                hops += 1
+                continue
+
+            return
 
 
 class EasyEquitiesClient(PlatformClient):

--- a/src/easy_equities_client/clients.py
+++ b/src/easy_equities_client/clients.py
@@ -5,7 +5,10 @@ from urllib.parse import urljoin
 from requests import Response, Session
 
 from easy_equities_client import constants
-from easy_equities_client.accounts.clients import AccountsClient
+from easy_equities_client.accounts.clients import (
+    AccountsClient,
+    EasyEquitiesAccountsClient,
+)
 from easy_equities_client.instruments.clients import InstrumentsClient
 from easy_equities_client.types import Client
 
@@ -59,9 +62,13 @@ class PlatformClient(Client):
     and https://platform.satrixnow.co.za.
     """
 
+    # Subclasses (EasyEquitiesClient) override this to plug in a richer
+    # AccountsClient without duplicating the rest of __init__.
+    accounts_client_class = AccountsClient
+
     def __init__(self, base_url, session: Session = None):
         super().__init__(base_url, session)
-        self.accounts = AccountsClient(base_url, self.session)
+        self.accounts = self.accounts_client_class(base_url, self.session)
         self.instruments = InstrumentsClient(base_url, self.session)
         self._mfa_token: str | None = None
         self._mfa_url: str | None = None
@@ -205,6 +212,10 @@ class EasyEquitiesClient(PlatformClient):
     """
     Client to interact with EasyEquities.
     """
+
+    # Tries the modern portfolio-overview REST API first, falling back to
+    # the HTML-scraping AccountsClient - see EasyEquitiesAccountsClient.
+    accounts_client_class = EasyEquitiesAccountsClient
 
     def __init__(self, base_url: str = constants.EASY_EQUITIES_BASE_PLATFORM_URL):
         return super().__init__(base_url)

--- a/src/easy_equities_client/constants.py
+++ b/src/easy_equities_client/constants.py
@@ -17,6 +17,11 @@ class Platform(CustomEnum):
 EASY_EQUITIES_BASE_PLATFORM_URL = "https://platform.easyequities.io"
 SATRIX_BASE_PLATFORM_URL = "https://platform.satrixnow.co.za"
 
+# Login now happens on a separate OIDC identity provider ("EasyID") rather
+# than directly on the platform site - see PlatformClient.login()'s
+# docstring for the full flow.
+IDENTITY_BASE_URL = "https://identity.openeasy.io"
+
 PLATFORM_SIGN_IN_PATH = "/Account/SignIn"
 PLATFORM_ACCOUNT_OVERVIEW_PATH = "/AccountOverview"
 PLATFORM_CAN_USE_ACCOUNT_PATH = "/Menu/CanUseSelectedAccount"

--- a/tests/accounts/test_clients.py
+++ b/tests/accounts/test_clients.py
@@ -6,8 +6,10 @@ import pytest
 from easy_equities_client import constants
 from easy_equities_client.accounts.clients import (
     AccountsClient,
+    EasyEquitiesAccountsClient,
     UnsupportedAccountError,
 )
+from easy_equities_client.accounts.rest import PortfolioApiError
 from easy_equities_client.accounts.types import Account
 
 
@@ -242,3 +244,113 @@ class TestAccountsClient:
         client = AccountsClient(base_platform_url)
         result = client.transactions_for_period("1", start_date, end_date)
         assert result == expected_output
+
+
+class TestEasyEquitiesAccountsClient:
+    """EasyEquitiesAccountsClient prefers the portfolio REST API and falls
+    back to the same HTML-scraping AccountsClient already tested above -
+    these tests only cover the REST-vs-fallback wiring, not re-testing the
+    HTML scraping or REST mapping logic themselves (see test_clients.py's
+    AccountsClient tests and test_rest.py)."""
+
+    def test_list_uses_rest_api(self, base_platform_url, mocker):
+        mocker.patch(
+            "easy_equities_client.accounts.clients.fetch_portfolio_overview",
+            return_value={
+                "investmentAccounts": [
+                    {
+                        "accountNumber": "EE1-1",
+                        "productName": "EasyEquities ZAR",
+                        "productId": 2,
+                    }
+                ]
+            },
+        )
+        client = EasyEquitiesAccountsClient(base_platform_url)
+        assert client.list() == [
+            Account(id="1", name="EasyEquities ZAR", trading_currency_id="2")
+        ]
+
+    def test_list_falls_back_to_html_on_rest_failure(self, base_platform_url, mocker):
+        mocker.patch(
+            "easy_equities_client.accounts.clients.fetch_portfolio_overview",
+            side_effect=PortfolioApiError("REST API unavailable"),
+        )
+        html_fallback = mocker.patch(
+            "easy_equities_client.accounts.clients.AccountsClient.list",
+            return_value=[Account(id="1", name="Test", trading_currency_id="1000")],
+        )
+        client = EasyEquitiesAccountsClient(base_platform_url)
+        assert client.list() == [
+            Account(id="1", name="Test", trading_currency_id="1000")
+        ]
+        html_fallback.assert_called_once()
+
+    def test_holdings_uses_rest_api(self, base_platform_url, mocker):
+        mocker.patch(
+            "easy_equities_client.accounts.clients.fetch_portfolio_overview",
+            return_value={
+                "investmentAccounts": [
+                    {
+                        "accountNumber": "EE1-1",
+                        "currencySymbol": "R",
+                        "assets": [
+                            {
+                                "assetName": "Test Asset",
+                                "contractCode": "TST",
+                                "assetCode": "ZAE000000001",
+                                "purchaseValue": 100,
+                                "currentValue": 110,
+                                "currentPrice": 11,
+                                "units": 10,
+                            }
+                        ],
+                    }
+                ]
+            },
+        )
+        client = EasyEquitiesAccountsClient(base_platform_url)
+        holdings = client.holdings("1")
+        assert len(holdings) == 1
+        assert holdings[0]["name"] == "Test Asset"
+        assert holdings[0]["current_value"] == "R110.00"
+
+    def test_holdings_falls_back_to_html_on_rest_failure(
+        self, base_platform_url, mocker
+    ):
+        mocker.patch(
+            "easy_equities_client.accounts.clients.fetch_portfolio_overview",
+            side_effect=PortfolioApiError("REST API unavailable"),
+        )
+        html_fallback = mocker.patch(
+            "easy_equities_client.accounts.clients.AccountsClient.holdings",
+            return_value=[{"name": "HTML fallback holding"}],
+        )
+        client = EasyEquitiesAccountsClient(base_platform_url)
+        assert client.holdings("1") == [{"name": "HTML fallback holding"}]
+        html_fallback.assert_called_once_with("1", include_shares=False)
+
+    def test_holdings_falls_back_when_account_not_in_rest_response(
+        self, base_platform_url, mocker
+    ):
+        mocker.patch(
+            "easy_equities_client.accounts.clients.fetch_portfolio_overview",
+            return_value={"investmentAccounts": []},
+        )
+        html_fallback = mocker.patch(
+            "easy_equities_client.accounts.clients.AccountsClient.holdings",
+            return_value=[{"name": "HTML fallback holding"}],
+        )
+        client = EasyEquitiesAccountsClient(base_platform_url)
+        assert client.holdings("1") == [{"name": "HTML fallback holding"}]
+        html_fallback.assert_called_once()
+
+    def test_portfolio_is_cached_across_calls(self, base_platform_url, mocker):
+        rest_mock = mocker.patch(
+            "easy_equities_client.accounts.clients.fetch_portfolio_overview",
+            return_value={"investmentAccounts": []},
+        )
+        client = EasyEquitiesAccountsClient(base_platform_url)
+        client.list()
+        client.list()
+        rest_mock.assert_called_once()

--- a/tests/accounts/test_clients.py
+++ b/tests/accounts/test_clients.py
@@ -1,12 +1,45 @@
 import json
 from datetime import date
 
+import pytest
+
 from easy_equities_client import constants
-from easy_equities_client.accounts.clients import AccountsClient
+from easy_equities_client.accounts.clients import (
+    AccountsClient,
+    UnsupportedAccountError,
+)
 from easy_equities_client.accounts.types import Account
 
 
 class TestAccountsClient:
+    def test_switch_account(self, base_platform_url, requests_mock):
+        url = base_platform_url + constants.PLATFORM_UPDATE_CURRENCY_PATH
+        requests_mock.post(url, status_code=200, text="")
+        client = AccountsClient(base_platform_url)
+        client._switch_account("1")
+        assert client.current_account == "1"
+
+    def test_switch_account_raises_for_separate_platform(
+        self, base_platform_url, requests_mock
+    ):
+        # EasyProperties, EasyCrypto etc. appear in the account list but are
+        # hosted on an entirely separate site - "switching" to one just
+        # tells a browser to open a new tab, it doesn't select an account
+        # here.
+        url = base_platform_url + constants.PLATFORM_UPDATE_CURRENCY_PATH
+        requests_mock.post(
+            url,
+            status_code=200,
+            text='"NEWTAB-https://platform.easyproperties.co.za"',
+        )
+        client = AccountsClient(base_platform_url)
+        with pytest.raises(UnsupportedAccountError):
+            client._switch_account("10328939")
+        # Must not look like a successful switch happened - otherwise the
+        # *next* real account's holdings() would silently reuse whatever
+        # was actually selected before this call.
+        assert client.current_account is None
+
     def test_get_account_overview_page(self, base_platform_url, requests_mock):
         url = base_platform_url + constants.PLATFORM_ACCOUNT_OVERVIEW_PATH
         text = b"My Investments"

--- a/tests/accounts/test_rest.py
+++ b/tests/accounts/test_rest.py
@@ -1,0 +1,167 @@
+import pytest
+from requests import Session
+
+from easy_equities_client.accounts.rest import (
+    PortfolioApiError,
+    account_id_from_account_number,
+    fetch_portfolio_overview,
+    get_portfolio_access_token,
+    rest_account_to_account,
+    rest_assets_to_holdings,
+)
+from easy_equities_client.accounts.types import Account
+
+
+class TestAccountIdFromAccountNumber:
+    def test_regular_trust_account(self):
+        # Matches the id AccountsClient's HTML-scraping already uses for
+        # this account, so a linked account keeps the same row either way.
+        assert account_id_from_account_number("EE1744408-7944922") == "7944922"
+
+    def test_non_numbered_product(self):
+        # EasyCrypto and similar EasyEquities-family products aren't a
+        # numbered trust account at all.
+        assert account_id_from_account_number("NBF523") == "NBF523"
+
+
+class TestRestAccountToAccount:
+    def test_maps_fields(self):
+        account = rest_account_to_account(
+            {
+                "accountNumber": "EE1744408-7944922",
+                "productName": "EasyEquities ZAR",
+                "productId": 2,
+            }
+        )
+        assert account == Account(
+            id="7944922", name="EasyEquities ZAR", trading_currency_id="2"
+        )
+
+    def test_missing_product_id(self):
+        account = rest_account_to_account(
+            {"accountNumber": "NBF523", "productName": "EasyCrypto"}
+        )
+        assert account.trading_currency_id == ""
+
+
+class TestRestAssetsToHoldings:
+    def test_maps_and_formats_currency(self):
+        holdings = rest_assets_to_holdings(
+            {
+                "currencySymbol": "R",
+                "assets": [
+                    {
+                        "assetName": "Kibo Energy PLC",
+                        "contractCode": "EQU.ZA.KBO",
+                        "assetCode": "IE00B97C0C31",
+                        "purchaseValue": 2490.68,
+                        "currentValue": 2605.45,
+                        "currentPrice": 64.08,
+                        "units": 200.0123,
+                        "imageUri": "aHR0cHM6Ly9leGFtcGxlLmNvbS9sb2dvLnBuZw==",
+                    }
+                ],
+            }
+        )
+        assert holdings == [
+            {
+                "name": "Kibo Energy PLC",
+                "contract_code": "EQU.ZA.KBO",
+                "purchase_value": "R2 490.68",
+                "current_value": "R2 605.45",
+                "current_price": "R64.08",
+                "isin": "IE00B97C0C31",
+                "shares": "200.0123",
+                "img": "https://example.com/logo.png",
+            }
+        ]
+
+    def test_negative_value(self):
+        holdings = rest_assets_to_holdings(
+            {
+                "currencySymbol": "$",
+                "assets": [
+                    {
+                        "assetName": "Losing position",
+                        "contractCode": "X",
+                        "assetCode": "X",
+                        "purchaseValue": 1,
+                        "currentValue": -0.11,
+                        "currentPrice": 1,
+                        "units": 1,
+                    }
+                ],
+            }
+        )
+        assert holdings[0]["current_value"] == "-$0.11"
+
+    def test_no_assets(self):
+        assert rest_assets_to_holdings({"currencySymbol": "R", "assets": []}) == []
+
+
+class TestGetPortfolioAccessToken:
+    def test_raises_when_not_a_redirect(self, requests_mock):
+        requests_mock.get(
+            "https://identity.openeasy.io/connect/authorize",
+            status_code=200,
+            text="not logged in",
+        )
+        with pytest.raises(PortfolioApiError):
+            get_portfolio_access_token(Session())
+
+    def test_raises_when_token_exchange_fails(self, requests_mock):
+        requests_mock.get(
+            "https://identity.openeasy.io/connect/authorize",
+            status_code=302,
+            headers={
+                "Location": "https://portfolio-overview.apps.easyequities.io/auth/callback?code=abc&state=xyz"
+            },
+        )
+        requests_mock.post(
+            "https://identity.openeasy.io/connect/token",
+            status_code=200,
+            json={"error": "invalid_grant"},
+        )
+        with pytest.raises(PortfolioApiError):
+            get_portfolio_access_token(Session())
+
+    def test_returns_access_token(self, requests_mock):
+        requests_mock.get(
+            "https://identity.openeasy.io/connect/authorize",
+            status_code=302,
+            headers={
+                "Location": "https://portfolio-overview.apps.easyequities.io/auth/callback?code=abc&state=xyz"
+            },
+        )
+        requests_mock.post(
+            "https://identity.openeasy.io/connect/token",
+            status_code=200,
+            json={"access_token": "test-token"},
+        )
+        assert get_portfolio_access_token(Session()) == "test-token"
+
+
+class TestFetchPortfolioOverview:
+    def test_raises_on_non_200(self, requests_mock, mocker):
+        mocker.patch(
+            "easy_equities_client.accounts.rest.get_portfolio_access_token",
+            return_value="test-token",
+        )
+        requests_mock.get(
+            "https://rest.synatic.openeasy.io/easyequities/portfolios/v3/portfolio-overview",
+            status_code=500,
+        )
+        with pytest.raises(PortfolioApiError):
+            fetch_portfolio_overview(Session())
+
+    def test_returns_json(self, requests_mock, mocker):
+        mocker.patch(
+            "easy_equities_client.accounts.rest.get_portfolio_access_token",
+            return_value="test-token",
+        )
+        requests_mock.get(
+            "https://rest.synatic.openeasy.io/easyequities/portfolios/v3/portfolio-overview",
+            status_code=200,
+            json={"investmentAccounts": []},
+        )
+        assert fetch_portfolio_overview(Session()) == {"investmentAccounts": []}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,13 +15,97 @@ def base_platform_url():
     return "https://platform.test.io"
 
 
+_SIGNIN_PAGE_HTML = """
+<html><body><form>
+<input type="hidden" name="__RequestVerificationToken" value="test-token" />
+<input type="hidden" name="ReturnUrl" value="/connect/authorize/callback?state=abc" />
+<input type="hidden" name="ClientIdForProperties" value="test-client-id" />
+</form></body></html>
+"""
+
+_MFA_PAGE_HTML = """
+<html><body><form>
+<input type="hidden" name="__RequestVerificationToken" value="test-mfa-token" />
+</form></body></html>
+"""
+
+_FORM_POST_CALLBACK_HTML = """
+<html><body><form method='post' action='{platform_url}'>
+<input type='hidden' name='code' value='test-auth-code' />
+</form></body></html>
+"""
+
+
 @pytest.fixture
 def mock_success_login_response(requests_mock):
+    """Mocks a full login with no MFA challenge: sign-in page -> POST ->
+    redirect straight through to a final landing page."""
+
     def _mock_success_login_response(base_url):
-        url = base_url + constants.PLATFORM_SIGN_IN_PATH
-        requests_mock.post(url, status_code=302)
+        signin_url = base_url + constants.PLATFORM_SIGN_IN_PATH
+        requests_mock.get(signin_url, text=_SIGNIN_PAGE_HTML)
+        requests_mock.post(
+            signin_url, status_code=302, headers={"Location": "/Dashboard"}
+        )
+        requests_mock.get(base_url + "/Dashboard", status_code=200, text="ok")
 
     return _mock_success_login_response
+
+
+@pytest.fixture
+def mock_mfa_login_response(requests_mock):
+    """Mocks a login that requires an authenticator-app code: sign-in page
+    -> POST -> redirect to the MFA challenge page."""
+
+    def _mock_mfa_login_response(base_url):
+        signin_url = base_url + constants.PLATFORM_SIGN_IN_PATH
+        # Real EasyID lives on a separate domain (identity.openeasy.io);
+        # this test keeps everything on base_url as a stand-in for "wherever
+        # the redirect chain currently is" - the code under test resolves
+        # each hop with urljoin() against the actual response URL, so it
+        # doesn't care which host is used as long as it's followed
+        # consistently.
+        mfa_url = base_url + "/Mfa/Authenticate"
+        requests_mock.get(signin_url, text=_SIGNIN_PAGE_HTML)
+        requests_mock.post(
+            signin_url, status_code=302, headers={"Location": "/Mfa/Authenticate"}
+        )
+        requests_mock.get(mfa_url, text=_MFA_PAGE_HTML)
+        return mfa_url
+
+    return _mock_mfa_login_response
+
+
+@pytest.fixture
+def mock_verify_mfa_response(requests_mock):
+    """Mocks a successful code verification: POST to the MFA endpoint ->
+    redirect to an OIDC form_post callback page -> auto-submit POST to the
+    platform site -> final landing page."""
+
+    def _mock_verify_mfa_response(base_url, mfa_url, valid_code):
+        callback_url = base_url + "/connect/authorize/callback"
+
+        requests_mock.post(
+            mfa_url,
+            status_code=200,
+            text="Error\nInvalid Code",
+            additional_matcher=lambda r: f"Code={valid_code}" not in (r.text or ""),
+        )
+        requests_mock.post(
+            mfa_url,
+            status_code=302,
+            headers={"Location": callback_url},
+            additional_matcher=lambda r: f"Code={valid_code}" in (r.text or ""),
+        )
+        requests_mock.get(
+            callback_url,
+            text=_FORM_POST_CALLBACK_HTML.format(
+                platform_url=base_url + "/AccountOverview"
+            ),
+        )
+        requests_mock.post(base_url + "/AccountOverview", status_code=200, text="ok")
+
+    return _mock_verify_mfa_response
 
 
 @pytest.fixture

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -1,4 +1,7 @@
+import pytest
+
 from easy_equities_client import constants
+from easy_equities_client.clients import MfaRequiredError
 
 
 class TestPlatformClient:
@@ -7,6 +10,40 @@ class TestPlatformClient:
     ):
         mock_success_login_response(base_platform_url)
         assert platform_client.login("username", "password") is True
+
+    def test_login_requires_mfa(
+        self, platform_client, base_platform_url, mock_mfa_login_response
+    ):
+        mock_mfa_login_response(base_platform_url)
+        with pytest.raises(MfaRequiredError):
+            platform_client.login("username", "password")
+
+    def test_verify_mfa(
+        self,
+        platform_client,
+        base_platform_url,
+        mock_mfa_login_response,
+        mock_verify_mfa_response,
+    ):
+        mfa_url = mock_mfa_login_response(base_platform_url)
+        with pytest.raises(MfaRequiredError):
+            platform_client.login("username", "password")
+        mock_verify_mfa_response(base_platform_url, mfa_url, valid_code="123456")
+        assert platform_client.verify_mfa("123456") is True
+
+    def test_verify_mfa_invalid_code(
+        self,
+        platform_client,
+        base_platform_url,
+        mock_mfa_login_response,
+        mock_verify_mfa_response,
+    ):
+        mfa_url = mock_mfa_login_response(base_platform_url)
+        with pytest.raises(MfaRequiredError):
+            platform_client.login("username", "password")
+        mock_verify_mfa_response(base_platform_url, mfa_url, valid_code="123456")
+        with pytest.raises(Exception, match="Invalid verification code"):
+            platform_client.verify_mfa("000000")
 
 
 class TestEasyEquitiesClient:


### PR DESCRIPTION
## What broke

EasyEquities moved login to a separate OIDC identity provider (`identity.openeasy.io`, "EasyID") and now requires a TOTP authenticator-app code as a second factor. The existing `login()` (a single POST of username+password straight to `platform.easyequities.io`) can no longer authenticate at all - not a partial regression, a full break for anyone with MFA enabled (which appears to be everyone now).

## The fix

Rebuilt `login()` against the real OIDC flow (reverse-engineered from a live browser session - request/response shapes, the `response_mode=form_post` callback, etc.) as a two-step API:

```python
try:
    client.login(username, password)
except MfaRequiredError:
    client.verify_mfa(code=input("Authenticator code: "))
```

`login()` returns `True` directly if MFA isn't required (kept for forward-compatibility, though not exercised on my test account); otherwise it raises `MfaRequiredError` and `verify_mfa(code)` completes login on the same client instance. Every redirect hop is resolved with `urljoin()` against the actual response URL rather than a hardcoded host, since the chain crosses from the identity provider back to the platform site partway through - including the final `response_mode=form_post` hop, which is an HTML page with an auto-submitting `<form>` rather than a plain HTTP redirect, and needs to be parsed and replicated by hand.

## A real data-corruption bug found along the way

Once login actually worked, I found `accounts.list()` returns entries (EasyProperties, EasyCrypto, ...) that aren't real trust accounts on this platform at all - they're pointers to entirely separate EasyEquities-family sites with their own login and data. `_switch_account()` was silently treating the "open a new tab" signal as a successful switch, so the *next* `holdings()` call for such an account silently returned whatever account was actually still selected. Concretely, on my own account, EasyProperties was reporting another account's exact balance. `_switch_account()` now raises `UnsupportedAccountError` instead, without corrupting `current_account`.

## New: REST API support, with the HTML-scraping path kept as a fallback

Also discovered that the modern portfolio-overview web app (a separate SPA at `portfolio-overview.apps.easyequities.io`) calls a clean JSON REST API instead of scraping `platform.easyequities.io`'s server-rendered pages. It's registered as its own OAuth2 client; since an `EasyEquitiesClient` session is already authenticated with `identity.openeasy.io` after `login()`/`verify_mfa()`, a silent re-authorization for that client (fresh PKCE pair generated locally) gets a Bearer token with no extra prompts. In exchange, one API call returns **every** EasyEquities-family account with exact values - including EasyProperties and EasyCrypto, which have no equivalent in the HTML-scraped account list at all.

`EasyEquitiesAccountsClient` (used automatically by `EasyEquitiesClient`) tries this REST API first and transparently falls back to the existing HTML-scraping behavior - kept exactly as-is, not replaced - if the REST call fails for any reason, so a future change to this undocumented API doesn't break callers outright. `SatrixClient` is unaffected; this is EasyEquities-specific. Account ids match exactly between both sources, so switching between the two paths never produces duplicates for a caller already tracking an account.

## Testing

- 39 tests passing (18 new, covering the login/MFA flow, the `UnsupportedAccountError` fix, and the REST client with its fallback wiring)
- `ruff check`/`ruff format --check` clean
- Verified end-to-end against a real EasyEquities account via the public API (`login()` → `verify_mfa()` → `accounts.list()` → `holdings()`) - all 6 accounts, correct values, holdings mapped into the same shape the HTML scraping already produced

Happy to adjust scope/approach if you'd rather split this into smaller PRs or take a different direction on any part of it.